### PR TITLE
Enhance device log management with retention settings and maintenance

### DIFF
--- a/app_config.php
+++ b/app_config.php
@@ -35,7 +35,7 @@
 	//default settings
 		$y=0;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "dc9776ee-a2ae-4e6b-821c-dc5a51df1b1f";
-		$apps[$x]['default_settings'][$y]['default_setting_category'] = "device";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "device_logs";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "database_retention_days";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "30";

--- a/app_config.php
+++ b/app_config.php
@@ -39,7 +39,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "database_retention_days";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "30";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Number of days maintenance application will retain device logs in the database.";
 
 	//device Logs

--- a/app_config.php
+++ b/app_config.php
@@ -32,6 +32,16 @@
 		$apps[$x]['permissions'][$y]['groups'][] = 'superadmin';
 		$y++;
 
+	//default settings
+		$y=0;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "dc9776ee-a2ae-4e6b-821c-dc5a51df1b1f";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "device";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "database_retention_days";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "30";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Number of days maintenance application will retain device logs in the database.";
+
 	//device Logs
 		$y = 0;
 		$apps[$x]['db'][$y]['table']['name'] = 'v_device_logs';

--- a/app_config.php
+++ b/app_config.php
@@ -5,7 +5,7 @@
 		$apps[$x]['uuid'] = '78b1e5c7-5028-43e7-a05b-a36b44f87087';
 		$apps[$x]['category'] = '';
 		$apps[$x]['subcategory'] = '';
-		$apps[$x]['version'] = '1.3';
+		$apps[$x]['version'] = '1.4';
 		$apps[$x]['license'] = 'BSD';
 		$apps[$x]['url'] = 'http://www.fusionpbx.com';
 		$apps[$x]['description']['en-us'] = '';

--- a/resources/classes/device_logs.php
+++ b/resources/classes/device_logs.php
@@ -259,6 +259,55 @@ class device_logs {
 		}
 	}
 
-}
+	/**
+	 * Removes old entries in the database device_logs table
+	 * see {@link https://github.com/fusionpbx/fusionpbx-app-maintenance/} FusionPBX Maintenance App
+	 *
+	 * @param settings $settings Settings object
+	 *
+	 * @return void
+	 */
 
-?>
+	public static function database_maintenance(settings $settings): void {
+		//set table name for query
+		$table = 'device_logs';
+
+		//get a database connection
+		$database = $settings->database();
+
+		//get a list of domains
+		$domains = maintenance::get_domains($database);
+		foreach ($domains as $domain_uuid => $domain_name) {
+
+			//get domain settings
+			$domain_settings = new settings(['database' => $database, 'domain_uuid' => $domain_uuid]);
+
+			//get the retention days for device log table using 'device' and 'database_retention_days'
+			$device_log_retention_days = $domain_settings->get('device', 'database_retention_days', '');
+
+			//ensure we have retention days
+			if (!empty($device_log_retention_days) && is_numeric((int)$device_log_retention_days)) {
+
+				//clear out old device_log records
+				$sql = "delete from v_{$table} WHERE insert_date < NOW() - INTERVAL '{$device_log_retention_days} days'"
+					. " and domain_uuid = '{$domain_uuid}'";
+				$database->execute($sql);
+				$code = $database->message['code'] ?? 0;
+				//record result
+				if ($code == 200) {
+					maintenance_service::log_write(self::class, "Successfully removed entries older than $device_log_retention_days", $domain_uuid);
+				} else {
+					$message = $database->message['message'] ?? "An unknown error has occurred";
+					maintenance_service::log_write(self::class, "device log " . "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
+				}
+			} else {
+				//report an invalid setting
+				maintenance_service::log_write(self::class, "Retention days not set or not a numeric value", $domain_uuid, maintenance_service::LOG_ERROR);
+			}
+		}
+
+		//ensure logs are saved
+		maintenance_service::log_flush();
+	}
+
+}

--- a/resources/classes/device_logs.php
+++ b/resources/classes/device_logs.php
@@ -310,4 +310,12 @@ class device_logs {
 		maintenance_service::log_flush();
 	}
 
+	public static function database_maintenance_category(): string {
+		return "device_logs";
+	}
+
+	public static function database_maintenance_subcategory(): string {
+		return "database_retention_days";
+	}
+
 }

--- a/resources/classes/device_logs.php
+++ b/resources/classes/device_logs.php
@@ -283,7 +283,7 @@ class device_logs {
 			$domain_settings = new settings(['database' => $database, 'domain_uuid' => $domain_uuid]);
 
 			//get the retention days for device log table using 'device' and 'database_retention_days'
-			$device_log_retention_days = $domain_settings->get('device', 'database_retention_days', '');
+			$device_log_retention_days = $domain_settings->get('device_logs', 'database_retention_days', '');
 
 			//ensure we have retention days
 			if (!empty($device_log_retention_days) && is_numeric((int)$device_log_retention_days)) {


### PR DESCRIPTION
This pull request introduces maintenance functionality for device logs, allowing old log entries to be automatically removed from the database based on a configurable retention period.

**Device log maintenance functionality:**

* Added a new static method `database_maintenance` to the `device_logs` class, which removes old entries from the `device_logs` table according to a per-domain retention period setting. The method logs results and errors for each domain.
* Added helper methods `database_maintenance_category` and `database_maintenance_subcategory` to the `device_logs` class to specify the relevant settings keys for the maintenance app.

**Configuration and settings:**

* Added a default setting in `app_config.php` for `device_logs` database retention, setting the default to 30 days and enabling it by default.
* Updated the app version in `app_config.php` from `1.3` to `1.4` to reflect these changes.

These changes bring this app in line with the XML_CDR and Fax Queue apps (among others).